### PR TITLE
Make `arrow` rounded

### DIFF
--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -33,7 +33,7 @@ const arrowStyles = css`
   background: #fff;
   border: 0;
   color: ${color.blue};
-  border-radius: 4px;
+  border-radius: 50%;
   box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.2);
   font-size: 12px;
   width: 30px;


### PR DESCRIPTION
The arrow looks better if it's rounded!
Why not let those default options `configurable`?